### PR TITLE
Fix canvas focus on load

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,13 +1,17 @@
 // Inicializar el juego cuando la página esté cargada
 document.addEventListener('DOMContentLoaded', () => {
+    const canvas = document.getElementById('gameCanvas');
+
+    // Permitir que el canvas reciba eventos de teclado
+    canvas.tabIndex = 1000;
+    // Dar foco inicial al canvas para que los controles funcionen enseguida
+    canvas.focus();
+
+    // Mantener el foco cuando se haga clic
+    canvas.addEventListener('click', () => {
+        canvas.focus();
+    });
+
     const juego = new JuegoAtrapaFrutas();
     juego.iniciar();
 });
-
-// Asegurar que el canvas mantenga el foco para los eventos de teclado
-document.getElementById('gameCanvas').addEventListener('click', () => {
-    document.getElementById('gameCanvas').focus();
-});
-
-// Permitir que el canvas reciba eventos de teclado
-document.getElementById('gameCanvas').tabIndex = 1000;


### PR DESCRIPTION
## Summary
- keep keyboard focus on the game canvas when the page loads
- ensure the canvas receives focus again when clicked

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_b_688316b8a19c832dbf70969767bd94ad