### PR TITLE
Add start menu and ranking overlay

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,7 @@ m4/lt~obsolete.m4
 # can automatically generate from config.status script
 # (which is called by configure script))
 Makefile
+
+# Node and build
+node_modules/
+dist/

--- a/game/Game.js
+++ b/game/Game.js
@@ -16,6 +16,7 @@ class JuegoAtrapaFrutas {
         
         this.estado = "jugando";
         this.ultimoTiempo = 0;
+        this.finalMostrado = false;
         
         this.configurarEventos();
     }
@@ -50,6 +51,10 @@ class JuegoAtrapaFrutas {
         this.controladorFrutas = new ControladorFrutas();
         this.detectorColisiones.reiniciar();
         this.estado = "jugando";
+        this.finalMostrado = false;
+        if (window.mostrarMenu) {
+            window.mostrarMenu();
+        }
     }
 
     actualizar() {
@@ -65,6 +70,13 @@ class JuegoAtrapaFrutas {
             this.detectorColisiones.verificarColisiones(
                 this.cesta, this.controladorFrutas);
             this.estado = this.detectorColisiones.verificarCondicionesJuego();
+            if (this.estado !== "jugando" && !this.finalMostrado) {
+                this.finalMostrado = true;
+                if (window.mostrarFinJuego) {
+                    window.mostrarFinJuego(this.estado,
+                        this.detectorColisiones.obtenerPuntos());
+                }
+            }
         }
     }
 
@@ -95,6 +107,7 @@ class JuegoAtrapaFrutas {
     }
 
     iniciar() {
+        this.finalMostrado = false;
         console.log("🍎 ¡Bienvenido a Atrapa Frutas - Edición Premium! 🍎");
         console.log("\n🎯 Sistema de Puntuación por Colores:");
         Object.entries(TIPOS_FRUTAS).forEach(([tipo, info]) => {

--- a/index.html
+++ b/index.html
@@ -7,6 +7,28 @@
     <link rel="stylesheet" href="styles.css">
 </head>
 <body>
+    <div id="startMenu" class="menu-overlay hidden">
+        <h2>Atrapa Frutas</h2>
+        <label>Nombre del jugador:
+            <input id="playerName" type="text" placeholder="Tu nombre" />
+        </label>
+        <div class="buttons">
+            <button id="startButton">Empezar</button>
+            <button id="rankingButton">Rankings</button>
+        </div>
+    </div>
+
+    <div id="rankingMenu" class="menu-overlay hidden">
+        <h2>Rankings</h2>
+        <ol id="rankingList"></ol>
+        <button id="backButton">Volver</button>
+    </div>
+
+    <div id="endMenu" class="menu-overlay hidden">
+        <h2 id="endMessage"></h2>
+        <button id="restartButton">Volver al Menú</button>
+    </div>
+
     <div class="container">
         <h1>🍎 Atrapa Frutas - Edición Premium 🍎</h1>
         <div class="game-container">

--- a/script.js
+++ b/script.js
@@ -1,17 +1,75 @@
-// Inicializar el juego cuando la página esté cargada
+let juego = null;
+let nombreJugador = '';
+
+function mostrarMenu(id) {
+    document.getElementById('startMenu').classList.add('hidden');
+    document.getElementById('rankingMenu').classList.add('hidden');
+    document.getElementById('endMenu').classList.add('hidden');
+
+    if (id) {
+        document.getElementById(id).classList.remove('hidden');
+    }
+}
+
+function actualizarRankings() {
+    const lista = document.getElementById('rankingList');
+    lista.innerHTML = '';
+    const rankings = JSON.parse(localStorage.getItem('rankings') || '[]');
+    rankings.sort((a, b) => b.puntos - a.puntos);
+    rankings.slice(0, 5).forEach((r, i) => {
+        const li = document.createElement('li');
+        li.textContent = `${i + 1}. ${r.nombre} - ${r.puntos}`;
+        lista.appendChild(li);
+    });
+}
+
+function mostrarFinJuego(estado, puntos) {
+    const mensaje = document.getElementById('endMessage');
+    if (estado === 'victoria') {
+        mensaje.textContent = `\u00a1Victoria! Puntos: ${puntos}`;
+    } else {
+        mensaje.textContent = `Game Over - Puntos: ${puntos}`;
+    }
+
+    const rankings = JSON.parse(localStorage.getItem('rankings') || '[]');
+    rankings.push({ nombre: nombreJugador || 'Jugador', puntos });
+    localStorage.setItem('rankings', JSON.stringify(rankings));
+    mostrarMenu('endMenu');
+}
+
+// Inicializar la página cuando esté cargada
 document.addEventListener('DOMContentLoaded', () => {
     const canvas = document.getElementById('gameCanvas');
-
-    // Permitir que el canvas reciba eventos de teclado
     canvas.tabIndex = 1000;
-    // Dar foco inicial al canvas para que los controles funcionen enseguida
-    canvas.focus();
+    canvas.addEventListener('click', () => canvas.focus());
 
-    // Mantener el foco cuando se haga clic
-    canvas.addEventListener('click', () => {
+    document.getElementById('startButton').addEventListener('click', () => {
+        nombreJugador = document.getElementById('playerName').value || 'Jugador';
+        document.querySelector('.container').classList.remove('hidden');
+        mostrarMenu();
         canvas.focus();
+        juego = new JuegoAtrapaFrutas();
+        juego.iniciar();
     });
 
-    const juego = new JuegoAtrapaFrutas();
-    juego.iniciar();
+    document.getElementById('rankingButton').addEventListener('click', () => {
+        actualizarRankings();
+        mostrarMenu('rankingMenu');
+    });
+
+    document.getElementById('backButton').addEventListener('click', () => {
+        mostrarMenu('startMenu');
+    });
+
+    document.getElementById('restartButton').addEventListener('click', () => {
+        mostrarMenu('startMenu');
+        document.querySelector('.container').classList.add('hidden');
+    });
+
+    mostrarMenu('startMenu');
+    document.querySelector('.container').classList.add('hidden');
 });
+
+// Expone la función para que Game.js pueda llamar cuando termine
+window.mostrarFinJuego = mostrarFinJuego;
+window.mostrarMenu = mostrarMenu;

--- a/styles.css
+++ b/styles.css
@@ -55,6 +55,50 @@ h1 {
     font-size: 1.1rem;
 }
 
+/* Menus */
+.menu-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0,0,0,0.6);
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    z-index: 10;
+}
+
+.menu-overlay h2 {
+    color: white;
+    margin-bottom: 15px;
+}
+
+.menu-overlay label {
+    color: white;
+    margin-bottom: 10px;
+}
+
+.menu-overlay .buttons button,
+#restartButton,
+#backButton {
+    margin: 5px;
+    padding: 8px 16px;
+    font-size: 1rem;
+    border: none;
+    border-radius: 5px;
+    cursor: pointer;
+}
+
+.menu-overlay .buttons {
+    margin-top: 10px;
+}
+
+.hidden {
+    display: none;
+}
+
 /* Responsive design */
 @media (max-width: 850px) {
     .container {


### PR DESCRIPTION
## Summary
- add start menu overlay with player name and rankings list
- provide ranking and end-game modals with buttons
- hide menus with helper functions and store results in localStorage
- expose helpers for end-game from Game.js and adjust game state
- style new overlays and ignore build artifacts

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_68831c8301e8832d9878238ed54fe895