### PR TITLE
Improve menu readability and transitions

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -20,6 +20,7 @@ body {
     border-radius: 20px;
     padding: 20px;
     box-shadow: 0 15px 35px rgba(0, 0, 0, 0.1);
+    transition: opacity 0.5s ease, visibility 0.5s ease;
 }
 
 h1 {
@@ -68,6 +69,7 @@ h1 {
     justify-content: center;
     align-items: center;
     z-index: 10;
+    transition: opacity 0.5s ease, visibility 0.5s ease;
 }
 
 .menu-overlay h2 {
@@ -78,6 +80,19 @@ h1 {
 .menu-overlay label {
     color: white;
     margin-bottom: 10px;
+}
+
+#rankingMenu ol {
+    color: white;
+    list-style-position: inside;
+    margin-bottom: 15px;
+}
+
+#startMenu input {
+    margin-left: 5px;
+    padding: 4px 8px;
+    border-radius: 4px;
+    border: none;
 }
 
 .menu-overlay .buttons button,
@@ -96,7 +111,9 @@ h1 {
 }
 
 .hidden {
-    display: none;
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
 }
 
 /* Responsive design */


### PR DESCRIPTION
## Summary
- add fade transitions for menu overlays and game container
- make ranking names white for readability
- polish start menu input styling
- build the project to ensure it still works

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68831ff521cc832d9770374fcc4081ac