### PR TITLE
Implement emoji fruits and progressive level unlock

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ Giggle Fruit is a lightweight minigame built primarily with JavaScript, along wi
 
 ## Features
 
-- Fun and simple gameplay
-- Runs in your browser
-- Easy to modify and extend
+- 🍎 Fun and simple gameplay
+- 🍌 Runs in your browser
+- 🍇 Easy to modify and extend
 
 ## Getting Started
 

--- a/game/FruitGenerator.js
+++ b/game/FruitGenerator.js
@@ -5,13 +5,13 @@
 
 // Sistema de frutas por valor (menor a mayor contraste/valor)
 const TIPOS_FRUTAS = {
-    'gris': { color: 'rgb(128, 128, 128)', puntos: 5, nombre: 'Gris' },
-    'verde': { color: 'rgb(34, 139, 34)', puntos: 10, nombre: 'Verde' },
-    'azul': { color: 'rgb(30, 144, 255)', puntos: 15, nombre: 'Azul' },
-    'rojo': { color: 'rgb(220, 20, 60)', puntos: 20, nombre: 'Rojo' },
-    'naranja': { color: 'rgb(255, 140, 0)', puntos: 25, nombre: 'Naranja' },
-    'oro': { color: 'rgb(255, 215, 0)', puntos: 30, nombre: 'Oro' },
-    'bomba': { color: 'rgb(0, 0, 0)', puntos: 0, nombre: 'Bomba', bomba: true }
+    'gris':   { color: 'rgb(128, 128, 128)', puntos: 5,  nombre: 'Gris',   emoji: '🍎' },
+    'verde':  { color: 'rgb(34, 139, 34)',   puntos: 10, nombre: 'Verde',  emoji: '🍏' },
+    'azul':   { color: 'rgb(30, 144, 255)',  puntos: 15, nombre: 'Azul',   emoji: '🫐' },
+    'rojo':   { color: 'rgb(220, 20, 60)',   puntos: 20, nombre: 'Rojo',   emoji: '🍒' },
+    'naranja':{ color: 'rgb(255, 140, 0)',   puntos: 25, nombre: 'Naranja',emoji: '🍊' },
+    'oro':    { color: 'rgb(255, 215, 0)',   puntos: 30, nombre: 'Oro',    emoji: '🍍' },
+    'bomba':  { color: 'rgb(0, 0, 0)',       puntos: 0,  nombre: 'Bomba',  emoji: '💣', bomba: true }
 };
 
 class GeneradorFrutas {
@@ -33,26 +33,14 @@ class GeneradorFrutas {
     }
 
     dibujar(ctx) {
-        const color = TIPOS_FRUTAS[this.tipo].color;
-        
-        // Dibujar círculo de la fruta
-        ctx.fillStyle = color;
-        ctx.beginPath();
-        ctx.arc(this.x, this.y, this.radio, 0, 2 * Math.PI);
-        ctx.fill();
-        
-        // Borde negro
-        ctx.strokeStyle = 'black';
-        ctx.lineWidth = 2;
-        ctx.stroke();
-        
-        // Efecto especial para frutas de oro
-        if (this.tipo === 'oro') {
-            ctx.fillStyle = 'white';
-            ctx.beginPath();
-            ctx.arc(this.x - 5, this.y - 5, 3, 0, 2 * Math.PI);
-            ctx.fill();
-        }
+        const emoji = TIPOS_FRUTAS[this.tipo].emoji;
+
+        ctx.font = '28px serif';
+        ctx.textAlign = 'center';
+        ctx.textBaseline = 'middle';
+        ctx.fillText(emoji, this.x, this.y);
+        ctx.textAlign = 'left';
+        ctx.textBaseline = 'alphabetic';
     }
 
     estaEnSuelo() {
@@ -82,6 +70,7 @@ class ControladorFrutas {
         this.frutas = [];
         this.tiempoUltimaFruta = 0;
         this.intervaloFruta = 1500; // milisegundos
+        this.nivel = 1;
         this.probabilidades = {
             'gris': 28,    // 28% probabilidad
             'verde': 23,   // 23% probabilidad
@@ -113,12 +102,12 @@ class ControladorFrutas {
             nuevaFruta.tipo = tipoSeleccionado;
             this.frutas.push(nuevaFruta);
             this.tiempoUltimaFruta = tiempoActual;
-            
-            // Aumentar dificultad gradualmente
-            if (this.intervaloFruta > 800) {
-                this.intervaloFruta -= 3;
-            }
         }
+    }
+
+    ajustarDificultadPorNivel(nivel) {
+        this.nivel = nivel;
+        this.intervaloFruta = Math.max(600, 1500 - (nivel - 1) * 100);
     }
 
     actualizarFrutas() {

--- a/game/Game.js
+++ b/game/Game.js
@@ -3,7 +3,7 @@
  * Clase principal que coordina todos los componentes del juego
  */
 class JuegoAtrapaFrutas {
-    constructor() {
+    constructor(nivelInicial = 1) {
         this.canvas = document.getElementById('gameCanvas');
         this.ctx = this.canvas.getContext('2d');
         this.teclasPresionadas = {};
@@ -13,10 +13,13 @@ class JuegoAtrapaFrutas {
         this.controladorFrutas = new ControladorFrutas();  // Integrante 2
         this.detectorColisiones = new DetectorColisiones();  // Integrante 3
         this.interfaz = new InterfazUsuario();  // Integrante 4
-        
+
         this.estado = "jugando";
         this.ultimoTiempo = 0;
         this.finalMostrado = false;
+        this.nivel = nivelInicial;
+        this.nivelInicial = nivelInicial;
+        this.controladorFrutas.ajustarDificultadPorNivel(this.nivel);
         
         this.configurarEventos();
     }
@@ -52,6 +55,8 @@ class JuegoAtrapaFrutas {
         this.detectorColisiones.reiniciar();
         this.estado = "jugando";
         this.finalMostrado = false;
+        this.nivel = this.nivelInicial;
+        this.controladorFrutas.ajustarDificultadPorNivel(this.nivel);
         if (window.mostrarMenu) {
             window.mostrarMenu();
         }
@@ -65,10 +70,16 @@ class JuegoAtrapaFrutas {
             // Generar y actualizar frutas (Integrante 2)
             this.controladorFrutas.generarFruta();
             this.controladorFrutas.actualizarFrutas();
-            
+
             // Detectar colisiones (Integrante 3)
             this.detectorColisiones.verificarColisiones(
                 this.cesta, this.controladorFrutas);
+            const nivelPorPuntos = Math.floor(this.detectorColisiones.obtenerPuntos() / 20) + 1;
+            const nuevoNivel = Math.min(10, Math.max(this.nivelInicial, nivelPorPuntos));
+            if (nuevoNivel !== this.nivel) {
+                this.nivel = nuevoNivel;
+                this.controladorFrutas.ajustarDificultadPorNivel(this.nivel);
+            }
             this.estado = this.detectorColisiones.verificarCondicionesJuego();
             if (this.estado !== "jugando" && !this.finalMostrado) {
                 this.finalMostrado = true;
@@ -89,7 +100,7 @@ class JuegoAtrapaFrutas {
             this.controladorFrutas.dibujarTodas(this.ctx);
         }
         
-        this.interfaz.dibujarHUD(this.ctx, this.detectorColisiones);
+        this.interfaz.dibujarHUD(this.ctx, this.detectorColisiones, this.nivel);
         this.interfaz.dibujarTablaValores(this.ctx);
         this.interfaz.dibujarControles(this.ctx);
         
@@ -114,6 +125,7 @@ class JuegoAtrapaFrutas {
             console.log(`   ${info.nombre}: ${info.puntos} puntos`);
         });
         console.log("\n🏆 Objetivo: Conseguir 200 puntos");
+        console.log(`🚀 Nivel inicial: ${this.nivelInicial}`);
         console.log("💖 Vidas: 5");
         console.log("\n🎮 Controles:");
         console.log("   ← → o A D: Mover cesta");

--- a/game/UserInterface.js
+++ b/game/UserInterface.js
@@ -7,27 +7,28 @@ class InterfazUsuario {
         // No necesitamos inicializar fuentes en Canvas, se configuran al dibujar
     }
 
-    dibujarHUD(ctx, detectorColisiones) {
+    dibujarHUD(ctx, detectorColisiones, nivel) {
         // Configurar fuente
         ctx.fillStyle = 'black';
         ctx.font = '24px Arial';
-        
-        // Puntos
-        ctx.fillText(`Puntos: ${detectorColisiones.obtenerPuntos()}`, 10, 35);
-        
-        // Vidas
-        ctx.fillText(`Vidas: ${detectorColisiones.obtenerVidas()}`, 10, 65);
-        
+
+        // Puntos y vidas
+        ctx.fillText(`🍓 Puntos: ${detectorColisiones.obtenerPuntos()}`, 10, 35);
+        ctx.fillText(`🍊 Vidas: ${detectorColisiones.obtenerVidas()}`, 10, 65);
+
+        // Nivel actual
+        ctx.fillText(`Nivel: ${nivel}`, 10, 95);
+
         // Objetivo
         ctx.font = '18px Arial';
-        ctx.fillText('Objetivo: 200 puntos', 10, 90);
+        ctx.fillText('Objetivo: 200 puntos', 10, 120);
         
         // Mensaje de puntos ganados
         const mensaje = detectorColisiones.obtenerMensajePunto();
         if (mensaje) {
             ctx.fillStyle = 'rgb(0, 150, 0)';
             ctx.font = '24px Arial';
-            ctx.fillText(mensaje, 800 / 2 - 100, 120); // ANCHO_PANTALLA
+            ctx.fillText(mensaje, 800 / 2 - 100, 150); // ANCHO_PANTALLA
         }
     }
 
@@ -41,23 +42,14 @@ class InterfazUsuario {
         
         let yOffset = yInicio + 25;
         Object.entries(TIPOS_FRUTAS).forEach(([tipo, info]) => {
-            // Dibujar círculo de color
-            ctx.fillStyle = info.color;
-            ctx.beginPath();
-            ctx.arc(xInicio + 10, yOffset, 8, 0, 2 * Math.PI);
-            ctx.fill();
-            
-            // Borde del círculo
-            ctx.strokeStyle = 'black';
-            ctx.lineWidth = 1;
-            ctx.stroke();
-            
-            // Dibujar texto
+            ctx.font = '20px Arial';
+            ctx.fillText(info.emoji, xInicio, yOffset + 6);
+
             ctx.fillStyle = 'black';
             ctx.font = '14px Arial';
             const texto = info.bomba ? `${info.nombre}: -1 vida` : `${info.nombre}: ${info.puntos} pts`;
-            ctx.fillText(texto, xInicio + 25, yOffset + 5);
-            yOffset += 18;
+            ctx.fillText(texto, xInicio + 25, yOffset + 10);
+            yOffset += 24;
         });
     }
 

--- a/index.html
+++ b/index.html
@@ -15,6 +15,9 @@
         <label>Nombre del jugador:
             <input id="playerName" type="text" placeholder="Tu nombre" />
         </label>
+        <label>Nivel:
+            <select id="levelSelect"></select>
+        </label>
         <div class="buttons">
             <button id="startButton">Empezar</button>
             <button id="rankingButton">Rankings</button>

--- a/script.js
+++ b/script.js
@@ -1,5 +1,19 @@
 let juego = null;
 let nombreJugador = '';
+let nivelSeleccionado = 1;
+
+function actualizarSelectorNiveles() {
+    const select = document.getElementById('levelSelect');
+    if (!select) return;
+    select.innerHTML = '';
+    const maxNivel = parseInt(localStorage.getItem('maxNivelDesbloqueado') || '1', 10);
+    for (let i = 1; i <= maxNivel; i++) {
+        const option = document.createElement('option');
+        option.value = i;
+        option.textContent = `Nivel ${i}`;
+        select.appendChild(option);
+    }
+}
 
 function mostrarMenu(id) {
     document.getElementById('startMenu').classList.add('hidden');
@@ -8,6 +22,9 @@ function mostrarMenu(id) {
 
     if (id) {
         document.getElementById(id).classList.remove('hidden');
+        if (id === 'startMenu') {
+            actualizarSelectorNiveles();
+        }
     }
 }
 
@@ -27,6 +44,10 @@ function mostrarFinJuego(estado, puntos) {
     const mensaje = document.getElementById('endMessage');
     if (estado === 'victoria') {
         mensaje.textContent = `\u00a1Victoria! Puntos: ${puntos}`;
+        const maxNivel = parseInt(localStorage.getItem('maxNivelDesbloqueado') || '1', 10);
+        if (nivelSeleccionado >= maxNivel && maxNivel < 10) {
+            localStorage.setItem('maxNivelDesbloqueado', nivelSeleccionado + 1);
+        }
     } else {
         mensaje.textContent = `Game Over - Puntos: ${puntos}`;
     }
@@ -43,12 +64,16 @@ document.addEventListener('DOMContentLoaded', () => {
     canvas.tabIndex = 1000;
     canvas.addEventListener('click', () => canvas.focus());
 
+    const select = document.getElementById('levelSelect');
+    actualizarSelectorNiveles();
+
     document.getElementById('startButton').addEventListener('click', () => {
         nombreJugador = document.getElementById('playerName').value || 'Jugador';
+        nivelSeleccionado = parseInt(select.value, 10);
         document.querySelector('.container').classList.remove('hidden');
         mostrarMenu();
         canvas.focus();
-        juego = new JuegoAtrapaFrutas();
+        juego = new JuegoAtrapaFrutas(nivelSeleccionado);
         juego.iniciar();
     });
 


### PR DESCRIPTION
## Summary
- replace fruit circles with fruit emojis
- show fruit emojis in the values table
- allow selecting a starting level on the menu
- unlock next level upon victory up to level 10
- level difficulty now starts from chosen level

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_688398e9d6a0832dbb6987ab53f59a2d