### PR TITLE
Add basic sound effects with Web Audio

### DIFF
--- a/game/CollisionDetector.js
+++ b/game/CollisionDetector.js
@@ -9,17 +9,20 @@ class DetectorColisiones {
         this.ultimoPuntoGanado = 0;
         this.mensajePunto = "";
         this.tiempoMensaje = 0;
+        this.frutaCapturada = false;
     }
 
     verificarColisiones(cesta, controladorFrutas) {
         const frutasAEliminar = [];
         const rectCesta = cesta.obtenerRectangulo();
-        
+        this.frutaCapturada = false;
+
         controladorFrutas.obtenerFrutas().forEach((fruta, i) => {
             const rectFruta = fruta.obtenerRectangulo();
             
             // Verificar colisión con la cesta
             if (this.colisionan(rectCesta, rectFruta)) {
+                this.frutaCapturada = true;
                 if (fruta.tipo === 'bomba') {
                     this.vidas -= 1;
                     this.mensajePunto = '-1 vida (Bomba)';
@@ -77,6 +80,7 @@ class DetectorColisiones {
         this.ultimoPuntoGanado = 0;
         this.mensajePunto = "";
         this.tiempoMensaje = 0;
+        this.frutaCapturada = false;
     }
 
     obtenerMensajePunto() {
@@ -85,5 +89,11 @@ class DetectorColisiones {
             return this.mensajePunto;
         }
         return "";
+    }
+
+    consumirFrutaCapturada() {
+        const capturada = this.frutaCapturada;
+        this.frutaCapturada = false;
+        return capturada;
     }
 }

--- a/game/Game.js
+++ b/game/Game.js
@@ -74,6 +74,11 @@ class JuegoAtrapaFrutas {
             // Detectar colisiones (Integrante 3)
             this.detectorColisiones.verificarColisiones(
                 this.cesta, this.controladorFrutas);
+            if (this.detectorColisiones.consumirFrutaCapturada()) {
+                if (window.soundManager) {
+                    window.soundManager.playCatch();
+                }
+            }
             const nivelPorPuntos = Math.floor(this.detectorColisiones.obtenerPuntos() / 20) + 1;
             const nuevoNivel = Math.min(10, Math.max(this.nivelInicial, nivelPorPuntos));
             if (nuevoNivel !== this.nivel) {

--- a/game/SoundManager.js
+++ b/game/SoundManager.js
@@ -1,0 +1,47 @@
+class SoundManager {
+    constructor() {
+        const AudioContext = window.AudioContext || window.webkitAudioContext;
+        this.context = new AudioContext();
+        this.menuAudio = document.getElementById('menuMusic');
+    }
+
+    playFrequency(freq, duration = 0.15) {
+        const osc = this.context.createOscillator();
+        const gain = this.context.createGain();
+        osc.type = 'sine';
+        osc.frequency.value = freq;
+        gain.gain.value = 0.1;
+        osc.connect(gain);
+        gain.connect(this.context.destination);
+        osc.start();
+        osc.stop(this.context.currentTime + duration);
+    }
+
+    playCatch() {
+        this.playFrequency(880);
+    }
+
+    playMenu() {
+        this.playFrequency(440);
+    }
+
+    playHover() {
+        this.playFrequency(660);
+    }
+
+    startMenuMusic() {
+        if (this.menuAudio) {
+            this.menuAudio.volume = 0.3;
+            this.menuAudio.play().catch(() => {});
+        }
+    }
+
+    stopMenuMusic() {
+        if (this.menuAudio) {
+            this.menuAudio.pause();
+            this.menuAudio.currentTime = 0;
+        }
+    }
+}
+
+window.soundManager = new SoundManager();

--- a/index.html
+++ b/index.html
@@ -10,6 +10,10 @@
     <link rel="stylesheet" href="styles.css">
 </head>
 <body>
+    <!-- Reproduce música de menú (puede reemplazarse por otro tema libre) -->
+    <audio id="menuMusic" loop>
+        <source src="https://files.freemusicarchive.org/storage-freemusicarchive/music/no_curator/BoxCat_Games/Ultimate_Ninja_Beats/BoxCat_Games_-_03_-_Run.mp3" type="audio/mpeg">
+    </audio>
     <div id="startMenu" class="menu-overlay hidden">
         <h2>Atrapa Frutas</h2>
         <label>Nombre del jugador:
@@ -52,6 +56,7 @@
     <script src="game/FruitGenerator.js"></script>
     <script src="game/CollisionDetector.js"></script>
     <script src="game/UserInterface.js"></script>
+    <script src="game/SoundManager.js"></script>
     <script src="game/Game.js"></script>
     <script src="script.js"></script>
 </body>

--- a/script.js
+++ b/script.js
@@ -26,9 +26,17 @@ function mostrarMenu(id) {
 
     if (id) {
         document.getElementById(id).classList.remove('hidden');
+        if (window.soundManager) {
+            window.soundManager.playMenu();
+            if (id === 'startMenu') {
+                window.soundManager.startMenuMusic();
+            }
+        }
         if (id === 'startMenu') {
             actualizarSelectorNiveles();
         }
+    } else if (window.soundManager) {
+        window.soundManager.stopMenuMusic();
     }
 }
 
@@ -74,7 +82,22 @@ document.addEventListener('DOMContentLoaded', () => {
     const select = document.getElementById('levelSelect');
     actualizarSelectorNiveles();
 
-    document.getElementById('startButton').addEventListener('click', () => {
+    const startBtn = document.getElementById('startButton');
+    const rankingBtn = document.getElementById('rankingButton');
+    const backBtn = document.getElementById('backButton');
+    const restartBtn = document.getElementById('restartButton');
+
+    const hoverSound = () => {
+        if (window.soundManager) {
+            window.soundManager.playHover();
+        }
+    };
+
+    [startBtn, rankingBtn, backBtn, restartBtn].forEach(btn => {
+        if (btn) btn.addEventListener('mouseover', hoverSound);
+    });
+
+    startBtn.addEventListener('click', () => {
         nombreJugador = document.getElementById('playerName').value || 'Jugador';
         nivelSeleccionado = parseInt(select.value, 10);
         document.querySelector('.container').classList.remove('hidden');
@@ -84,16 +107,16 @@ document.addEventListener('DOMContentLoaded', () => {
         juego.iniciar();
     });
 
-    document.getElementById('rankingButton').addEventListener('click', () => {
+    rankingBtn.addEventListener('click', () => {
         actualizarRankings();
         mostrarMenu('rankingMenu');
     });
 
-    document.getElementById('backButton').addEventListener('click', () => {
+    backBtn.addEventListener('click', () => {
         mostrarMenu('startMenu');
     });
 
-    document.getElementById('restartButton').addEventListener('click', () => {
+    restartBtn.addEventListener('click', () => {
         mostrarMenu('startMenu');
         document.querySelector('.container').classList.add('hidden');
     });


### PR DESCRIPTION
## Summary
- create `SoundManager` to play simple tones
- hook menu displays and hover events to sound effects
- play a sound when catching a fruit
- add menu background music placeholder

## Testing
- `npm install`
- `npm run build` *(warnings about `<script>` tags but build succeeds)*

------
https://chatgpt.com/codex/tasks/task_b_6883a40f7994832d97ce9b4ed9157000